### PR TITLE
Upgrade bcprov-jdk15on to version 1.66

### DIFF
--- a/module-maven1/pom.xml
+++ b/module-maven1/pom.xml
@@ -21,5 +21,10 @@
             <artifactId>jsoup</artifactId>
             <version>1.7.2</version>
         </dependency>
-    </dependencies>
+      <dependency>
+         <groupId>org.bouncycastle</groupId>
+         <artifactId>bcprov-jdk15on</artifactId>
+         <version>1.66</version>
+      </dependency>
+   </dependencies>
 </project>

--- a/module-maven2/pom.xml
+++ b/module-maven2/pom.xml
@@ -21,5 +21,10 @@
             <artifactId>poi</artifactId>
             <version>3.17</version>
         </dependency>
-    </dependencies>
+      <dependency>
+         <groupId>org.bouncycastle</groupId>
+         <artifactId>bcprov-jdk15on</artifactId>
+         <version>1.66</version>
+      </dependency>
+   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example.app</groupId>
@@ -15,7 +17,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.66</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades bcprov-jdk15on to 1.66 to fix vulnerabilities in current version